### PR TITLE
Update gem versions

### DIFF
--- a/miyabi.gemspec
+++ b/miyabi.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_dependency "mechanize", "2.7.5"
+  spec.add_development_dependency "rspec", "~> 3.12"
+  spec.add_dependency "mechanize", "~> 2.9"
 end

--- a/miyabi.gemspec
+++ b/miyabi.gemspec
@@ -21,8 +21,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.15"
-  spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_dependency "mechanize", "2.7.5"
 end


### PR DESCRIPTION
By updating gem versions, The following errors will be no longer encountered:

```shell-session
$ bundle
Fetching gem metadata from https://rubygems.org/......
Resolving dependencies...
Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    bundler (~> 1.15)

  Current Bundler version:
    bundler (2.3.22)

Your bundle requires a different version of Bundler than the one you're running.
Install the necessary version with `gem install bundler:1.17.3` and rerun bundler using `bundle _1.17.3_`
```

```shell-session
$ bundle _1.17.3_ exec rake spec
/Users/gemmaro/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-1.17.3/lib/bundler/shared_helpers.rb:29: warning: Pathname#untaint is deprecated and will be removed in Ruby 3.2.
/Users/gemmaro/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-1.17.3/lib/bundler/shared_helpers.rb:118: warning: Pathname#untaint is deprecated and will be removed in Ruby 3.2.
/Users/gemmaro/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-1.17.3/lib/bundler/shared_helpers.rb:118: warning: Pathname#untaint is deprecated and will be removed in Ruby 3.2.
/Users/gemmaro/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-1.17.3/lib/bundler/shared_helpers.rb:35: warning: Pathname#untaint is deprecated and will be removed in Ruby 3.2.
/Users/gemmaro/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-1.17.3/lib/bundler/shared_helpers.rb:35: warning: Pathname#untaint is deprecated and will be removed in Ruby 3.2.
/Users/gemmaro/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-1.17.3/lib/bundler/shared_helpers.rb:44: warning: Pathname#untaint is deprecated and will be removed in Ruby 3.2.
/Users/gemmaro/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-1.17.3/lib/bundler/shared_helpers.rb:118: warning: Pathname#untaint is deprecated and will be removed in Ruby 3.2.
/Users/gemmaro/.rbenv/versions/3.1.2/bin/ruby -I/Users/gemmaro/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib:/Users/gemmaro/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-support-3.11.1/lib /Users/gemmaro/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
/Users/gemmaro/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-1.17.3/lib/bundler/shared_helpers.rb:29: warning: Pathname#untaint is deprecated and will be removed in Ruby 3.2.
/Users/gemmaro/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-1.17.3/lib/bundler/shared_helpers.rb:118: warning: Pathname#untaint is deprecated and will be removed in Ruby 3.2.
/Users/gemmaro/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-1.17.3/lib/bundler/shared_helpers.rb:118: warning: Pathname#untaint is deprecated and will be removed in Ruby 3.2.
/Users/gemmaro/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-1.17.3/lib/bundler/shared_helpers.rb:35: warning: Pathname#untaint is deprecated and will be removed in Ruby 3.2.
/Users/gemmaro/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-1.17.3/lib/bundler/shared_helpers.rb:35: warning: Pathname#untaint is deprecated and will be removed in Ruby 3.2.
/Users/gemmaro/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-1.17.3/lib/bundler/shared_helpers.rb:44: warning: Pathname#untaint is deprecated and will be removed in Ruby 3.2.
/Users/gemmaro/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-1.17.3/lib/bundler/shared_helpers.rb:118: warning: Pathname#untaint is deprecated and will be removed in Ruby 3.2.

An error occurred while loading ./spec/miyabi_spec.rb.
Failure/Error: require 'mechanize'

LoadError:
  cannot load such file -- webrick/httputils
# ./lib/format.rb:1:in `require'
# ./lib/format.rb:1:in `<top (required)>'
# ./lib/miyabi.rb:2:in `require'
# ./lib/miyabi.rb:2:in `<top (required)>'
# ./spec/spec_helper.rb:2:in `require'
# ./spec/spec_helper.rb:2:in `<top (required)>'
# ./spec/miyabi_spec.rb:1:in `require'
# ./spec/miyabi_spec.rb:1:in `<top (required)>'
No examples found.

Finished in 0.0001 seconds (files took 0.83222 seconds to load)
0 examples, 0 failures, 1 error occurred outside of examples

/Users/gemmaro/.rbenv/versions/3.1.2/bin/ruby -I/Users/gemmaro/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib:/Users/gemmaro/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-support-3.11.1/lib /Users/gemmaro/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb failed
```